### PR TITLE
Paged Embed Utility + Paged Commands

### DIFF
--- a/commands/system/help.js
+++ b/commands/system/help.js
@@ -53,7 +53,7 @@ class Help extends Command {
       if (num) {
         embed.setTitle("Command category help")
           .setDescription(`A list of commands in the ${type} category.\n(Total of ${num} commands in this category)\n\nTo get help on a specific command do \`${message.settings.prefix}help <command>\`\n`);
-        const pages = peutil.splitFields(output, "\n", embed, perpage, "Commands");
+        const pages = peutil.splitFields(output, "\n", perpage, embed, "Commands");
         if (pages.length === 1) return message.channel.send({embed: pages[0]});
         return new peutil({caller: message.author, channel: message.channel})
           .addPages(pages).useReaction(peutil.EMOJIS.left, "prev")

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -1,4 +1,4 @@
-const { MessageEmbed, Message, TextChannel } = require("discord.js");
+const { Message, TextChannel, GuildMember, User} = require("discord.js");
 
 const EMOJIS = {
   "1234": "🔢",
@@ -43,19 +43,29 @@ const EMOJIS = {
 };
 
 module.exports = class PagedEmbedUtil {
-  constructor(msgOrChan) {
+  constructor(msgOrChan, caller) {
+
+    this.EMOJIS = EMOJIS;
 
     this.pages = [];
     this.currentPage = 0;
 
-    this.responseObj = {}; //object mapping emoji to action or function to be called, for example it might map ▶ to nextPage
+    this.responseMap = new Map(); //map, mapping emoji to action or function to be called, for example it might map ▶ to nextPage
     this.reactions = []; //array with emojis in order of how they should appear on the message
 
-    if (msgOrChan instanceof Message) this.message = msgOrChan;
-    else if (msgOrChan instanceof TextChannel) this.channel = msgOrChan;
-    else throw new TypeError("Input must be a message or channel object!");
+    if (msgOrChan instanceof Message) {
+      this.message = msgOrChan; 
+      this.channel = msgOrChan.channel;
+    } else if (msgOrChan instanceof TextChannel) this.channel = msgOrChan;
+    else throw new TypeError("First argument must be a message or channel object!");
     // if its a TextChannel, the message will be sent with the first page when the pagedembed is executed.
 
+    if (caller instanceof GuildMember) this.caller = caller;
+    if (caller instanceof User) this.caller = this.channel.guild.member(caller);
+    if (typeof caller === "string") this.caller = this.channel.guild.members.get(caller);
+    if (!caller) throw new TypeError("Second argument must be the member or user who instantiated the command");
+
+    this.collector = null;
   }
 
   addPage(embed) {
@@ -68,34 +78,90 @@ module.exports = class PagedEmbedUtil {
     return this;
   }
 
+  clearPages() {
+    this.pages = [];
+    return this;
+  }
+
   useReaction(emoji, action) {
+    const position = this.reactions.indexOf(emoji);
+    if (position !== -1) this.reactions.splice(position, 1);
     this.reactions.push(emoji);
     if (typeof action === "string") {
       if (["nextpage", "next"].indexOf(action) !== -1) action = this.nextPage;
       if (["prevpage", "prev"].indexOf(action) !== -1) action = this.prevPage;
+      if (["prompt", "goto", "gotopage", "ask"].indexOf(action) !== -1) action = this.createPrompt;
     }
 
-    this.responseObj[emoji];
+    this.responseMap.set(emoji, action);
+    return this;
+  }
+
+  clearReactions() {
+    this.responseMap.clear();
+    this.reactions = [];
+    return this;
   }
 
   nextPage() {
     this.currentPage++;
     if (this.currentPage >= this.pages.length) this.currentPage = 0;
-    return this.message.edit({ embed: this.pages[this.currentPage]});
+    return this._update();
   }
 
   prevPage() {
     this.currentPage--;
     if (this.currentPage < 0) this.currentPage = this.pages.length - 1;
-    return this.message.edit({ embed: this.pages[this.currentPage]});
+    return this._update();
   }
 
   pageTo(page) {
-    //...
+    if (typeof page === "string") page = Number(page);
+    if (!Number.isInteger(page)) return Promise.reject(new TypeError("Argument must be an integer"));
+    page--; // users will assume its 1-indexed and not 0-indexed
+    if (page < 0 || page >= this.pages.length) return Promise.reject(new TypeError("Out of page range"));
+    this.currentPage = page;
+    return this._update();
+  }
+
+  prompt() {
+    this.channel.client.awaitReply(this.message, "What page do you want to see? (Say `cancel` to cancel this prompt)", m => m.author.id === this.caller.user.id, undefined, null)
+    .then(response => {
+      if (response.toLowerCase().trim() === "cancel") return;
+      const page = Number(response);
+      if (isNaN(page)) return this.channel.send("That is not a valid response.");
+      return this.pageTo(page).catch(() => this.channel.send("That page does not exist."));
+    });
   }
 
   async run() {
     if (!this.message) this.message = await this.channel.send({ embed: this.pages[this.currentPage] });
+    for (const emoji of this.reactions) {
+      await this.message.react(emoji);
+    }
+
+    this.collector = this.message.createReactionCollector((reaction, user) => user === this.caller.user && this.reactions.indexOf(reaction.emoji.name) !== -1, {time: 15 * 60 * 1000});
+
+    this.collector.on("collect", r => {
+      const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
+      if (perms) r.remove(this.caller.user);
+      const cb = this.responseMap.get(r.emoji.name);
+      if (!cb) throw new TypeError(`Invalid action for emoji ${r.emoji.name}, must be a function or recognised string`);
+      cb();
+    });
+
+    this.collector.on("end", () => {
+      const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
+      if (perms) this.message.clearReactions();
+      else this.message.reactions.map(r => r.remove());
+    });
 
   }
+
+  _update() {
+    const embed = this.pages[this.currentPage];
+    embed.footer.text = `${this.currentPage + 1}/${this.pages.length}`; 
+    return this.message.edit({ embed });
+  }
+
 };

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -1,0 +1,101 @@
+const { MessageEmbed, Message, TextChannel } = require("discord.js");
+
+const EMOJIS = {
+  "1234": "🔢",
+  right: "▶",
+  forward: "▶",
+  backward: "◀",
+  left: "◀",
+  up: "🔼",
+  down: "🔽",
+  play: "▶",
+  pause: "⏸",
+  square: "⏹",
+  circle: "⏺",
+  next: "⏭",
+  prev: "⏮",
+  right_double: "⏩",
+  fast_forward: "⏩",
+  left_double: "⏪",
+  rewind: "⏪",
+  up_double: "⏫",
+  down_double: "⏬",
+  point_right: "➡",
+  right_arrow: "➡",
+  point_left: "⬅",
+  left_arrow: "⬅",
+  point_up: "⬆",
+  up_arrow: "⬆",
+  point_down: "⬇",
+  down_arrow: "⬇",
+  up_right_arrow: "↗",
+  point_up_right: "↗",
+  down_right_arrow: "↘",
+  point_down_right: "↘",
+  down_left_arrow: "↙",
+  point_down_left: "↙",
+  up_left_arrow: "↖",
+  point_up_left: "↖",
+  hook_right: "↪",
+  hook_left: "↩",
+  arrow_clockwise: "🔃",
+  reload: "🔃"
+};
+
+module.exports = class PagedEmbedUtil {
+  constructor(msgOrChan) {
+
+    this.pages = [];
+    this.currentPage = 0;
+
+    this.responseObj = {}; //object mapping emoji to action or function to be called, for example it might map ▶ to nextPage
+    this.reactions = []; //array with emojis in order of how they should appear on the message
+
+    if (msgOrChan instanceof Message) this.message = msgOrChan;
+    else if (msgOrChan instanceof TextChannel) this.channel = msgOrChan;
+    else throw new TypeError("Input must be a message or channel object!");
+    // if its a TextChannel, the message will be sent with the first page when the pagedembed is executed.
+
+  }
+
+  addPage(embed) {
+    this.pages.push(embed);
+    return this;
+  }
+
+  addPages(embeds) {
+    this.pages = this.pages.concat(embeds);
+    return this;
+  }
+
+  useReaction(emoji, action) {
+    this.reactions.push(emoji);
+    if (typeof action === "string") {
+      if (["nextpage", "next"].indexOf(action) !== -1) action = this.nextPage;
+      if (["prevpage", "prev"].indexOf(action) !== -1) action = this.prevPage;
+    }
+
+    this.responseObj[emoji];
+  }
+
+  nextPage() {
+    this.currentPage++;
+    if (this.currentPage >= this.pages.length) this.currentPage = 0;
+    return this.message.edit({ embed: this.pages[this.currentPage]});
+  }
+
+  prevPage() {
+    this.currentPage--;
+    if (this.currentPage < 0) this.currentPage = this.pages.length - 1;
+    return this.message.edit({ embed: this.pages[this.currentPage]});
+  }
+
+  pageTo(page) {
+    //...
+  }
+
+  async run() {
+    if (!this.message) this.message = await this.channel.send({ embed: this.pages[this.currentPage] });
+
+  }
+};

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -49,7 +49,21 @@ const EMOJIS = {
 
 };
 
+/**
+ * A utility that manages paged embeds.
+ */
+
 const peutil = class PagedEmbedUtil {
+  /**
+   * @typedef {object} PagedEmbedUtilOptions
+   * @property {User} [caller] The user who instantiated the command.
+   * @property {Message} [message] The message to edit with the paged embed. If there is no message,
+   * it will send a message instead.
+   * @property {Text}
+   */
+  /**
+   * @param {PagedEmbedUtilOptions} options 
+   */
   constructor(options = {}) {
 
     this.pages = [];

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -52,50 +52,143 @@ const EMOJIS = {
 /**
  * A utility that manages paged embeds.
  */
+class PagedEmbedUtil {
+  /**
+   * @typedef {object} PagedEmbedUtilOptions
+   * @property {User} [caller] - The user who instantiated the command.
+   * @property {Message} [message] - The message to edit with the paged embed. If there is no message,
+   * it will send a message instead.
+   * @property {TextChannel} [channel=PagedEmbedUtil#message] - The channel to post to. This value or PagedEmbedUtil#message must be filled in,
+   * otherwise this command will fail.
+   * @property {ReactionCollectorOptions} [collectorOptions={}] - Options to pass to the reaction collector, if any.
+   */
 
-const peutil = class PagedEmbedUtil {
-  
+  /**
+   * @param {PagedEmbedUtilOptions} options
+   */
   constructor(options = {}) {
 
+    /**
+     * Array of all pages, in the order they will appear in.
+    * @type {MessageEmbed[]} 
+     */
     this.pages = [];
+    /**
+     * The 0-indexed current page of the embed
+     * @type {Number} 
+     */
     this.currentPage = 0;
 
+    /**
+     * The map controlling the function of the embed. Maps reacted emoji to callback to execute.
+     * @type {Map<Emoji,Function>}
+     */
     this.responseMap = new Map(); //map, mapping emoji to action or function to be called, for example it might map ▶ to nextPage
+
+    /**
+     * An array of emojis in the order they should appear on the message.
+     * @type {Emoji[]}
+     */
     this.reactions = []; //array with emojis in order of how they should appear on the message
 
+    /**
+     * The message the paged embed is running on, if any.
+     * @type {Message|null}
+     */
     this.message = options.message || null; 
+
+    /**
+     * The channel the paged embed will appear in (or is currently in).
+     * @type {TextChannel}
+     */
     this.channel = options.channel || null;
 
+    /**
+     * The member who instantiated the command.
+     * @type {GuildMember}
+     */
     const caller = options.caller;
     if (caller instanceof GuildMember) this.caller = caller;
     if (caller instanceof User) this.caller = this.channel.guild.member(caller);
     if (typeof caller === "string") this.caller = this.channel.guild.members.get(caller);
     if (!caller) throw new TypeError("Option \"caller\" must be the member or user who instantiated the command");
 
+    /**
+     * The reaction collector being used, if there is one.
+     * @type {ReactionCollector}
+     */
     this.collector = null;
+
+    /**
+     * Options to be passed to the reaction collector.
+     * @type {ReactionCollectorOptions}
+     */
     this.collectorOptions = options.collectorOptions || {}; 
   }
 
+  /**
+   * Adds a single page to the paged embed.
+   * @see PagedEmbedUtil.splitFields
+   * @param {MessageEmbed} embed - The embed to add.
+   * @returns {PagedEmbedUtil}
+   */
   addPage(embed) {
     this.pages.push(embed);
     return this;
   }
 
+  /**
+   * Adds multiple pages to the paged embed
+   * @see PagedEmbedUtil.splitFields
+   * @param {MessageEmbed[]} embeds - The embeds to add.
+   * @returns {PagedEmbedUtil}
+   */
   addPages(embeds) {
     this.pages = this.pages.concat(embeds);
     return this;
   }
 
+  /**
+   * Set the pages of the paged embed to the array of embeds passed.
+   * @see PagedEmbedUtil.splitFields
+   * @param {MessageEmbed[]} embeds - The embeds to set the paged embed to use.
+   * @returns {PagedEmbedUtil}
+   */
   setPages(embeds) {
     this.pages = embeds;
     return this;
   }
 
+  /**
+   * Clears all the stored pages for the embed.
+   * @see PagedEmbedUtil#addPage
+   * @see PagedEmbedUtil#addPages
+   * @returns {PagedEmbedUtil}
+   */
   clearPages() {
     this.pages = [];
     return this;
   }
 
+  /**
+   * Adds a reaction to the embed, and associates it with a callback. This is then 
+   * stored in {@link PagedEmbedUtil#reactionMap} and {@link PagedEmbedUtil#reactions}.
+   * @param {Emoji} emoji - The emoji to react with, and associate with the callback
+   * It may be useful to use {@link PagedEmbedUtil.EMOJIS} for this.
+   * @param {Function|String} action - The callback to execute. If it is a string, it
+   * will be replaced with the corresponding function.
+   * * "nextPage", "next" will be replaced by {@link PagedEmbedUtil#nextPage}.
+   * * "prevPage", "prev" will be replaced by {@link PagedEmbedUtil#prevPage}.
+   * * "prompt", "goto", "gotoPage", "ask" will be replaced by {@link PagedEmbedUtil#prompt}
+   * Otherwise, the methods {@link PagedEmbedUtil#nextPage}, {@link PagedEmbedUtil#prevPage},
+   * {@link PagedEmbedUtil#prompt} and {@link PagedEmbedUtil#pageTo} should be used.
+   * @see PagedEmbedUtil#nextPage
+   * @see PagedEmbedUtil#prevPage
+   * @see PagedEmbedUtil#prompt
+   * @see PagedEmbedUtil#pageTo
+   * @see PagedEmbedUtil.EMOJIS
+   * @returns {PagedEmbedUtil}
+   */
   useReaction(emoji, action) {
     const position = this.reactions.indexOf(emoji);
     if (position !== -1) this.reactions.splice(position, 1);
@@ -103,18 +196,28 @@ const peutil = class PagedEmbedUtil {
     if (typeof action === "string") {
       if (["nextpage", "next"].indexOf(action) !== -1) action = this.nextPage.bind(this);
       if (["prevpage", "prev"].indexOf(action) !== -1) action = this.prevPage.bind(this);
-      if (["prompt", "goto", "gotopage", "ask"].indexOf(action) !== -1) action = this.createPrompt.bind(this);
+      if (["prompt", "goto", "gotoPage", "ask"].indexOf(action) !== -1) action = this.createPrompt.bind(this);
     }
     this.responseMap.set(emoji, action);
     return this;
   }
 
+  /**
+   * Clears all the reactions stored. This will not delete any reactions from the message.
+   * @see PagedEmbedUtil#reapplyReactions
+   * @returns {PagedEmbedUtil}
+   */
   clearReactions() {
     this.responseMap.clear();
     this.reactions = [];
     return this;
   }
 
+  /**
+   * Removes all reactions from a message, then re-adds them in the order defined in {@link PagedEmbedUtil#reactions}
+   * @async
+   * @returns {Promise<PagedEmbedUtil>}
+   */
   async reapplyReactions() {
     const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
     if (perms) this.message.reactions.removeAll();
@@ -125,6 +228,10 @@ const peutil = class PagedEmbedUtil {
     return this;
   }
 
+  /**
+   * Removes all reactions and stops the reaction collector.
+   * @returns {PagedEmbedUtil}
+   */
   end() {
     const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
     if (perms) this.message.reactions.removeAll();
@@ -133,18 +240,37 @@ const peutil = class PagedEmbedUtil {
     return this;
   }
 
+  /**
+   * Changes the embed to the next page.
+   * @see PagedEmbedUtil#useReaction
+   * @param {Boolean} [overlap=true] - Whether the embed should go to the first page if it is currently 
+   * on the last page. true for if it should overlap, false for if it should just do nothing.
+   * @returns {PagedEmbedUtil}
+   */
   nextPage(overlap = true) {
     this.currentPage++;
     if (this.currentPage >= this.pages.length) this.currentPage = overlap ?  0: this.pages.length - 1;
     return this._update();
   }
 
+  /**
+   * Changes the embed to the previous page.
+   * @see PagedEmbedUtil#useReaction
+   * @param {Boolean} [overlap=true] - Whether the embed should go to the last page if it is currently 
+   * on the first page. true for if it should overlap, false for if it should just do nothing.
+   * @returns {PagedEmbedUtil}
+   */
   prevPage(overlap = true) {
     this.currentPage--;
     if (this.currentPage < 0) this.currentPage = overlap ? this.pages.length - 1 : 0;
     return this._update();
   }
 
+  /**
+   * Changes the page of the embed to a specified page.
+   * @param {Number|String} page - The 1-indexed page that the embed should be changed to.
+   * @returns {PagedEmbedUtil}
+   */
   pageTo(page) {
     if (typeof page === "string") page = Number(page);
     if (!Number.isInteger(page)) throw new TypeError("Argument must be an integer");
@@ -154,6 +280,11 @@ const peutil = class PagedEmbedUtil {
     return this._update();
   }
 
+  /**
+   * Prompts the user to go to a specific page.
+   * @see PagedEmbedUtil#pageTo
+   * @returns {PagedEmbedUtil}
+   */
   prompt() {
     this.channel.client.awaitReply(this.message, "What page do you want to see? (Say `cancel` to cancel this prompt)", m => m.author.id === this.caller.user.id, undefined, null)
       .then(response => {
@@ -162,8 +293,15 @@ const peutil = class PagedEmbedUtil {
         if (isNaN(page)) return this.channel.send("That is not a valid response.");
         return this.pageTo(page).catch(() => this.channel.send("That page does not exist."));
       });
+    return this;
   }
 
+  /**
+   * Runs the embed. A message will be sent if none was provided, a
+   * reaction collector will be created, and the message will have reactions applied to it.
+   * @async
+   * @returns {Promise<PagedEmbedUtil>}
+   */
   async run() {
     if (!this.message) {
       const embed = this.pages[this.currentPage];
@@ -190,6 +328,9 @@ const peutil = class PagedEmbedUtil {
     return this;
   }
 
+  /**
+   * Updates the embed to be on the correct page.
+   */
   _update() {
     const embed = this.pages[this.currentPage];
     if (!embed) return;
@@ -199,7 +340,22 @@ const peutil = class PagedEmbedUtil {
     return this.message.edit({ embed });
   }
 
-  static splitFields(string, splitRegex = /(\n|\.)/,embed, perPage = 10, fieldTitle = "\u200b") {
+  /**
+   * Splits a string into pages that conform to embed limits. If an embed is provided, 
+   * it will return an array of embeds with identical properties, but different field values.
+   * @param {String} string - The string to be split.
+   * @param {String|RegExp} [splitRegex=/(\n|\.)/] - The regex to split by. Note that
+   * if a string is provided, it will be converted to an embed with new RegExp(`(${splitRegex})`).
+   * This is so that when .split() is called on the string, the split parts are kept in the array.
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split}
+   * @param {Number} [perPage=10] - The number of split elements per page
+   * @param {MessageEmbed} [embed] - The embed to copy the fields into.
+   * @param {String} [fieldTitle="\u200b"] - The field title to use for the embeds.
+   * 
+   * @static
+   * @returns {String[]|MessageEmbed[]}
+   */
+  static splitFields(string, splitRegex = /(\n|\.)/, perPage = 10, embed, fieldTitle = "\u200b") {
     if (typeof splitRegex === "string") splitRegex = new RegExp(`(${splitRegex})`);
     const split = string.split(splitRegex).reduce((acc, b, i) => {//first iteration of i is 0
       if (i % 2 === 0) acc.push(b);
@@ -213,16 +369,26 @@ const peutil = class PagedEmbedUtil {
     }, [""]).filter(a => /[^\n\s]+/.test(a));
 
     if (!embed) return split;
-    console.log(split);
     return split.map(e => this.cloneEmbed(embed).addField(fieldTitle, e));
 
   }
 
+  /**
+   * Deep clones an embed.
+   * @param {MessageEmbed} embed - The embed to deep clone.
+   * @returns {MessageEmbed}
+   */
   static cloneEmbed(embed) {
     return Object.assign(new MessageEmbed(), JSON.parse(JSON.stringify(embed)));
   }
-};
+}
 
-peutil.EMOJIS = EMOJIS;
+/**
+ * An object with lots of useful unicode emojis.
+ * @constant
+ * @see PagedEmbedUtil#useReaction
+ * @type {Object}
+ */
+PagedEmbedUtil.EMOJIS = EMOJIS;
 
-module.exports = peutil;
+module.exports = PagedEmbedUtil;

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -54,16 +54,7 @@ const EMOJIS = {
  */
 
 const peutil = class PagedEmbedUtil {
-  /**
-   * @typedef {object} PagedEmbedUtilOptions
-   * @property {User} [caller] The user who instantiated the command.
-   * @property {Message} [message] The message to edit with the paged embed. If there is no message,
-   * it will send a message instead.
-   * @property {Text}
-   */
-  /**
-   * @param {PagedEmbedUtilOptions} options 
-   */
+  
   constructor(options = {}) {
 
     this.pages = [];
@@ -74,7 +65,6 @@ const peutil = class PagedEmbedUtil {
 
     this.message = options.message || null; 
     this.channel = options.channel || null;
-    // if its a TextChannel, the message will be sent with the first page when the pagedembed is executed.
 
     const caller = options.caller;
     if (caller instanceof GuildMember) this.caller = caller;
@@ -125,10 +115,14 @@ const peutil = class PagedEmbedUtil {
     return this;
   }
 
-  reapplyReactions() {
+  async reapplyReactions() {
     const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
     if (perms) this.message.reactions.removeAll();
     else this.message.reactions.map(r => r.users.remove());
+    for (const emoji of this.reactions) {
+      await this.message.react(emoji);
+    }
+    return this;
   }
 
   end() {
@@ -136,6 +130,7 @@ const peutil = class PagedEmbedUtil {
     if (perms) this.message.reactions.removeAll();
     else this.message.reactions.map(r => r.users.remove());
     this.collector.stop();
+    return this;
   }
 
   nextPage(overlap = true) {
@@ -192,6 +187,7 @@ const peutil = class PagedEmbedUtil {
     });
 
     this.collector.on("end", () => this.end);
+    return this;
   }
 
   _update() {

--- a/util/PagedEmbedUtil.js
+++ b/util/PagedEmbedUtil.js
@@ -1,4 +1,4 @@
-const { Message, TextChannel, GuildMember, User} = require("discord.js");
+const { MessageEmbed, GuildMember, User} = require("discord.js");
 
 const EMOJIS = {
   "1234": "🔢",
@@ -42,10 +42,8 @@ const EMOJIS = {
   reload: "🔃"
 };
 
-module.exports = class PagedEmbedUtil {
-  constructor(msgOrChan, caller) {
-
-    this.EMOJIS = EMOJIS;
+const peutil = class PagedEmbedUtil {
+  constructor(options = {}) {
 
     this.pages = [];
     this.currentPage = 0;
@@ -53,19 +51,18 @@ module.exports = class PagedEmbedUtil {
     this.responseMap = new Map(); //map, mapping emoji to action or function to be called, for example it might map ▶ to nextPage
     this.reactions = []; //array with emojis in order of how they should appear on the message
 
-    if (msgOrChan instanceof Message) {
-      this.message = msgOrChan; 
-      this.channel = msgOrChan.channel;
-    } else if (msgOrChan instanceof TextChannel) this.channel = msgOrChan;
-    else throw new TypeError("First argument must be a message or channel object!");
+    this.message = options.message || null; 
+    this.channel = options.channel || null;
     // if its a TextChannel, the message will be sent with the first page when the pagedembed is executed.
 
+    const caller = options.caller;
     if (caller instanceof GuildMember) this.caller = caller;
     if (caller instanceof User) this.caller = this.channel.guild.member(caller);
     if (typeof caller === "string") this.caller = this.channel.guild.members.get(caller);
-    if (!caller) throw new TypeError("Second argument must be the member or user who instantiated the command");
+    if (!caller) throw new TypeError("Option \"caller\" must be the member or user who instantiated the command");
 
     this.collector = null;
+    this.collectorOptions = options.collectorOptions || {}; 
   }
 
   addPage(embed) {
@@ -75,6 +72,11 @@ module.exports = class PagedEmbedUtil {
 
   addPages(embeds) {
     this.pages = this.pages.concat(embeds);
+    return this;
+  }
+
+  setPages(embeds) {
+    this.pages = embeds;
     return this;
   }
 
@@ -88,11 +90,10 @@ module.exports = class PagedEmbedUtil {
     if (position !== -1) this.reactions.splice(position, 1);
     this.reactions.push(emoji);
     if (typeof action === "string") {
-      if (["nextpage", "next"].indexOf(action) !== -1) action = this.nextPage;
-      if (["prevpage", "prev"].indexOf(action) !== -1) action = this.prevPage;
-      if (["prompt", "goto", "gotopage", "ask"].indexOf(action) !== -1) action = this.createPrompt;
+      if (["nextpage", "next"].indexOf(action) !== -1) action = this.nextPage.bind(this);
+      if (["prevpage", "prev"].indexOf(action) !== -1) action = this.prevPage.bind(this);
+      if (["prompt", "goto", "gotopage", "ask"].indexOf(action) !== -1) action = this.createPrompt.bind(this);
     }
-
     this.responseMap.set(emoji, action);
     return this;
   }
@@ -117,9 +118,9 @@ module.exports = class PagedEmbedUtil {
 
   pageTo(page) {
     if (typeof page === "string") page = Number(page);
-    if (!Number.isInteger(page)) return Promise.reject(new TypeError("Argument must be an integer"));
+    if (!Number.isInteger(page)) throw new TypeError("Argument must be an integer");
     page--; // users will assume its 1-indexed and not 0-indexed
-    if (page < 0 || page >= this.pages.length) return Promise.reject(new TypeError("Out of page range"));
+    if (page < 0 || page >= this.pages.length) throw new RangeError("Out of page range");
     this.currentPage = page;
     return this._update();
   }
@@ -135,16 +136,23 @@ module.exports = class PagedEmbedUtil {
   }
 
   async run() {
-    if (!this.message) this.message = await this.channel.send({ embed: this.pages[this.currentPage] });
+    if (!this.message) {
+      const embed = this.pages[this.currentPage];
+      if (!embed) return;
+      embed.footer = {
+        text: `${this.currentPage + 1}/${this.pages.length}` 
+      };
+      this.message = await this.channel.send({ embed: this.pages[this.currentPage] });
+    }
     for (const emoji of this.reactions) {
       await this.message.react(emoji);
     }
 
-    this.collector = this.message.createReactionCollector((reaction, user) => user === this.caller.user && this.reactions.indexOf(reaction.emoji.name) !== -1, {time: 15 * 60 * 1000});
+    this.collector = this.message.createReactionCollector((reaction, user) => user === this.caller.user && this.reactions.indexOf(reaction.emoji.name) !== -1, {time: 15 * 60 * 1000}, this.collectorOptions);
 
     this.collector.on("collect", r => {
       const perms = this.channel.permissionsFor(this.channel.guild.me).has("MANAGE_REACTIONS");
-      if (perms) r.remove(this.caller.user);
+      if (perms) r.users.remove(this.caller.user);
       const cb = this.responseMap.get(r.emoji.name);
       if (!cb) throw new TypeError(`Invalid action for emoji ${r.emoji.name}, must be a function or recognised string`);
       cb();
@@ -155,13 +163,43 @@ module.exports = class PagedEmbedUtil {
       if (perms) this.message.clearReactions();
       else this.message.reactions.map(r => r.remove());
     });
-
   }
 
   _update() {
     const embed = this.pages[this.currentPage];
-    embed.footer.text = `${this.currentPage + 1}/${this.pages.length}`; 
+    if (!embed) return;
+    embed.footer = {
+      text: `${this.currentPage + 1}/${this.pages.length}` 
+    };
     return this.message.edit({ embed });
   }
 
+  static splitFields(string, embed, perPage = 2, fieldTitle = "\u200b") {
+    
+    const split = string.split(/(\n|\.)/).reduce((acc, b, i) => {
+      if (i % 2 === 1) acc.push(b);
+      else acc[acc.length - 1] += b;
+      return acc;
+    }, []).reduce((acc, b) => {
+      if (acc[acc.length - 1].length + b.length > 1024) acc.push(b);
+      else acc[acc.length - 1] += b;
+      return acc;
+    }, []);
+
+    if (!embed) return split;
+    return split.reduce((acc, b, i) => {
+      if (acc % perPage === 1) acc.push(this.cloneEmbed(embed));
+      acc[acc.length - 1].addField(i === 1 ? fieldTitle : "\u200b");
+    }, []);
+
+
+  }
+
+  static cloneEmbed(embed) {
+    return Object.assign(new MessageEmbed(), embed);
+  }
 };
+
+peutil.EMOJIS = EMOJIS;
+
+module.exports = peutil;


### PR DESCRIPTION
Alright so @gazmull totally has me beat here, but I've made it now so I might as well submit.

PagedEmbedUtil.js is a file containing a utility class that manages paged embeds.

~~**I am in the middle of adding documentation**, however I haven't worked with JSDoc ever and I'm still trying to get a feel for it.~~ **I have added documentation and I think it is in a good state.**

I've also modified help.js and xkcd.js to work with pages, for an idea of how this works see those files.

- Constructor takes options:

   - caller: The user who instantiated the command
  - message: The message to edit with the embed (if left blank a message will be sent)
  - channel: The channel to post to
   - reactionCollectorOptions: Any options to be passed to the reaction collector

- Static property EMOJIS, contains an object with lots of useful unicode emojis, in text form
- addPage(embed), addPages(embeds), clearPages() and setPages(embeds) methods controlling the various pages for the embed
- useReaction(emoji, callback) method.
  - For the first argument, using PagedEmbedUtil.EMOJIS is useful.
  - For the second argument, the strings "nextpage", "next", "prevpage", "prev", "prompt", "goto", "gotopage", "ask" can be used in place of the methods nextPage(), prevPage(), pageTo(page) and prompt(), or any callback can be used. There are examples in the xkcd.js command (which I've also paginated) and the help.js command.
 - nextPage(overlap), prevPage(overlap) go to the next page or previous page of the embed. The overlap parameter is a boolean that can be set to true if the pages should wrap around when going out of the page range, or false if they shouldn't.
- pageTo(page) to go to a specific page
- prompt() to prompt the user to go to a specific page
- run() to start the embed

- static method cloneEmbed(embed) to deep clone an embed
- static method splitFields(string, splitRegex ,embed, perPage, fieldTitle)
  - If supplied with just string and splitRegex, can be used to split a string into elements that are both within the embed limits and conform to pages (if you set perPage).
  - splitRegex is a string or regular expression to perform string.split() on. Keep in mind that if it is a string, it is converted to a regular expression with ```new RegExp(`(${splitRegex})`)```, which will keep all the elements that were split in the array.
  - If supplied with an embed, splitRegex will split by pages and fields, but also return an array of identical embeds, but with fields with differing pages. (Once again, see the help command for an example.)

I am open to criticism as I've never done this sort of thing before

~~kyra go easy on me pls~~