### PR TITLE
Allow Misaki to Handle Music

### DIFF
--- a/commands/music/loop.js
+++ b/commands/music/loop.js
@@ -1,0 +1,53 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Loop extends Command {
+  constructor(client) {
+    super(client, {
+      name: "loop",
+      description: "This command will display the current playing song.",
+      usage: "np",
+      category: "Music",
+      aliases: ["unloop"],
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing playing!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const loopedEmbed = new MessageEmbed()
+      .setAuthor("Looped")
+      .setDescription(`The song has been looped by ${message.member.displayName}`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      
+    const unLoopedEmbed = new MessageEmbed()
+      .setAuthor("Unlooped")
+      .setDescription(`The song has been unlooped by ${message.member.displayName}`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    if (thisPlaylist.loop) {
+      thisPlaylist.loop = false;
+      return message.channel.send(unLoopedEmbed);
+    } else {
+      thisPlaylist.loop = true;
+      return message.channel.send(loopedEmbed);
+    }
+  }
+}
+
+module.exports = Loop;

--- a/commands/music/np.js
+++ b/commands/music/np.js
@@ -1,0 +1,39 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class NP extends Command {
+  constructor(client) {
+    super(client, {
+      name: "np",
+      description: "This command will display the current playing song.",
+      usage: "np",
+      category: "Music",
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing playing!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+    const nowPlayingEmbed = new MessageEmbed()
+      .setDescription(`**Now Playing:** ${thisPlaylist.songs[0].title}`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    return message.channel.send(nowPlayingEmbed);
+  }
+}
+
+module.exports = NP;

--- a/commands/music/pause.js
+++ b/commands/music/pause.js
@@ -1,0 +1,48 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Pause extends Command {
+  constructor(client) {
+    super(client, {
+      name: "pause",
+      description: "This command will pause the current playing song.",
+      usage: "pause",
+      category: "Music",
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing to pause!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const pausedEmbed = new MessageEmbed()
+      .setAuthor("Paused")
+      .setDescription(`The song has been paused by ${message.member.displayName}.`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const alreadyPausedEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("The song is already paused!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    if (!thisPlaylist.playing) return message.channel.send(alreadyPausedEmbed);
+    thisPlaylist.playing = false;
+    thisPlaylist.connection.dispatcher.pause();
+    return message.channel.send(pausedEmbed);
+  }
+}
+
+module.exports = Pause;

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -1,0 +1,75 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+const ytapi = require("simple-youtube-api"); 
+const handleVideo = require("../../modules/MusicHandling.js");
+const youtube = new ytapi("YOUTUBE-API-KEY-HERE"); 
+
+class Play extends Command {
+  constructor(client) {
+    super(client, {
+      name: "play",
+      description: "This command will allow the bot to play a song.",
+      usage: "play <url|song-name>",
+      category: "Music",
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const url = args[0] ? args[0].replace(/<(.+)>/g, "$1") : "";
+    if (!args[0]) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("Please list a song you would like to play")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    const voiceChannel = message.member.voiceChannel;
+    if (!voiceChannel) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("I'm sorry but you need to be in a voice channel to play music!")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    const permissions = voiceChannel.permissionsFor(message.client.user);
+    if (!permissions.has("CONNECT")) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("I cannot connect to your voice channel, make sure I have the proper permissions!")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    if (!permissions.has("SPEAK")) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("I cannot speak in this voice channel, make sure I have the proper permissions!")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    if (url.match(/^https?:\/\/(www.youtube.com|youtube.com)\/playlist(.*)$/)) {
+      const playlist = await youtube.getPlaylist(url);
+      const videos = await playlist.getVideos();
+      for (const video of Object.values(videos)) {
+        const video2 = await youtube.getVideoByID(video.id); // eslint-disable-line no-await-in-loop
+        await handleVideo(video2, message, voiceChannel, true); // eslint-disable-line no-await-in-loop
+      }
+      const embed = new MessageEmbed()
+        .setAuthor("Playlist")
+        .setDescription(`✅ Playlist: **${playlist.title}** has been added to the queue!`)
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      message.channel.send(embed);
+    } else {
+      let video;
+      try {
+        video = await youtube.getVideo(url);
+      } catch (error) {
+        const videos = await youtube.searchVideos(args.join(" "), 1);
+        video = await youtube.getVideoByID(videos[0].id);          
+      }
+      return handleVideo(video, message, voiceChannel);
+    }
+  }
+}
+
+module.exports = Play;

--- a/commands/music/queue.js
+++ b/commands/music/queue.js
@@ -1,0 +1,40 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Queue extends Command {
+  constructor(client) {
+    super(client, {
+      name: "queue",
+      description: "This command will display all songs.",
+      usage: "queue",
+      category: "Music",
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+    const thisPlaylist =  this.client.playlists.get(message.guild.id);
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing playing!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    const queueEmbed = new MessageEmbed()
+      .setAuthor("Queue")
+      .setDescription(`${thisPlaylist.songs.map(song => `**-** ${song.title}`).join("\n")}`)
+      .setFooter(`Now playing: ${thisPlaylist.songs[0].title}`)      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    return message.channel.send(queueEmbed);
+  }
+}
+
+module.exports = Queue;

--- a/commands/music/resume.js
+++ b/commands/music/resume.js
@@ -1,0 +1,48 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Pause extends Command {
+  constructor(client) {
+    super(client, {
+      name: "resume",
+      description: "This command will resume the current playing song.",
+      usage: "resume",
+      category: "Music",
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing to resume!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const pausedEmbed = new MessageEmbed()
+      .setAuthor("Resume")
+      .setDescription(`The song has been resumed by ${message.member.displayName}.`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const notPausedEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("The song is not paused!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    if (thisPlaylist.playing) return message.channel.send(notPausedEmbed);
+    thisPlaylist.playing = true;
+    thisPlaylist.connection.dispatcher.resume();
+    return message.channel.send(pausedEmbed);
+  }
+}
+
+module.exports = Pause;

--- a/commands/music/search.js
+++ b/commands/music/search.js
@@ -2,7 +2,7 @@
 const Command = require(`${process.cwd()}/base/Command.js`);
 const { MessageEmbed } = require("discord.js");
 const ytapi = require("simple-youtube-api"); 
-const youtube = new ytapi("AIzaSyCqeZHQu2R-LrkPolNH_kfszTUjp3oUPls"); 
+const youtube = new ytapi("YOUTUBE-API-KEY-HERE"); 
 const handleVideo = require("../../modules/MusicHandling.js");
 
 class Search extends Command {

--- a/commands/music/search.js
+++ b/commands/music/search.js
@@ -1,0 +1,78 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+const ytapi = require("simple-youtube-api"); 
+const youtube = new ytapi("AIzaSyCqeZHQu2R-LrkPolNH_kfszTUjp3oUPls"); 
+const handleVideo = require("../../modules/MusicHandling.js");
+
+class Search extends Command {
+  constructor(client) {
+    super(client, {
+      name: "search",
+      description: "This command will allow a user to choose from 10 songs.",
+      usage: "search <song-name>",
+      category: "Music"
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    const permissions = voiceChannel.permissionsFor(message.client.user);
+    if (!permissions.has("CONNECT")) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("I cannot connect to your voice channel, make sure I have the proper permissions!")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    if (!permissions.has("SPEAK")) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("I cannot speak in this voice channel, make sure I have the proper permissions!")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    let video;
+    try {
+      const videos = await youtube.searchVideos(args.join(" "), 10);
+      let index = 0;
+      const embed = new MessageEmbed()
+        .setAuthor("Song Selection")
+        .setDescription(`${videos.map(video2 => `**${++index} -** ${video2.title}`).join("\n")}`)
+        .setFooter("Please provide a value to select one of the search results ranging from 1-10.")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      message.channel.send(embed);
+      let response;
+      try {
+        response = await message.channel.awaitMessages(msg2 => msg2.content > 0 && msg2.content < 11, {
+          max: 1,
+          time: 10000,
+          errors: ["time"]
+        });
+      } catch (err) {
+        const embed = new MessageEmbed()
+          .setAuthor("Error")
+          .setDescription("No or invalid value entered, cancelling video selection.")
+          .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+        return message.channel.send(embed);
+      }
+      const videoIndex = parseInt(response.first().content);
+      video = await youtube.getVideoByID(videos[videoIndex - 1].id);
+    } catch (err) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("🆘 I could not obtain any search results.")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+    return handleVideo(video, message, voiceChannel);
+  }
+}
+
+module.exports = Search;

--- a/commands/music/search.js
+++ b/commands/music/search.js
@@ -21,6 +21,13 @@ class Search extends Command {
       .setAuthor("Error")
       .setDescription("You must be in a voice channel first!")
       .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+    if (!args[0]) {
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription("Please list a song you would like to play")
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
 
     if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
     const permissions = voiceChannel.permissionsFor(message.client.user);

--- a/commands/music/skip.js
+++ b/commands/music/skip.js
@@ -1,0 +1,43 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Skip extends Command {
+  constructor(client) {
+    super(client, {
+      name: "skip",
+      description: "This command will skip a current playing song.",
+      usage: "skip",
+      category: "Music",
+      aliases: ["next"],
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing to skip!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const skippedEmbed = new MessageEmbed()
+      .setAuthor("Skipped")
+      .setDescription(`The song has been skipped by ${message.member.displayName}.`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+    thisPlaylist.loop = false;
+    thisPlaylist.connection.dispatcher.end("skip");
+    return message.channel.send(skippedEmbed);
+  }
+}
+
+module.exports = Skip;

--- a/commands/music/stop.js
+++ b/commands/music/stop.js
@@ -1,0 +1,43 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Stop extends Command {
+  constructor(client) {
+    super(client, {
+      name: "stop",
+      description: "This command will stop the current playing songs and clear the queue.",
+      usage: "stop",
+      category: "Music",
+      permLevel: "Administrator"
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing to stop!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const stoppedEmbed = new MessageEmbed()
+      .setAuthor("Stopped")
+      .setDescription(`The song has been stopped by ${message.member.displayName}.`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    const thisPlaylist = this.client.playlists.get(message.guild.id);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+    thisPlaylist.songs = [];
+    thisPlaylist.connection.dispatcher.end();
+    return message.channel.send(stoppedEmbed);
+  }
+}
+
+module.exports = Stop;

--- a/commands/music/volume.js
+++ b/commands/music/volume.js
@@ -1,0 +1,57 @@
+/* eslint linebreak-style: 0 */
+const Command = require(`${process.cwd()}/base/Command.js`);
+const { MessageEmbed } = require("discord.js");
+
+class Volume extends Command {
+  constructor(client) {
+    super(client, {
+      name: "volume",
+      description: "This command will set the volume of the songs.",
+      usage: "volume [number]",
+      category: "Music",
+      permLevel: "Administrator"
+    });
+  }
+
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const voiceChannel = message.member.voiceChannel;
+
+    const noVoiceChannelEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("You must be in a voice channel first!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const emptyQueueEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("There is nothing playing!")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    const errorVolumeEmbed = new MessageEmbed()
+      .setAuthor("Error")
+      .setDescription("Volume must be a value between 0 and 100.")
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+
+    if (!voiceChannel) return message.channel.send(noVoiceChannelEmbed);
+    if (!this.client.playlists.has(message.guild.id)) return message.channel.send(emptyQueueEmbed);
+
+    const currentVolumeEmbed = new MessageEmbed()
+      .setAuthor("Volume")
+      .setDescription(`Current volume is ${this.client.playlists.get(message.guild.id).connection.dispatcher.volumeLogarithmic * 100}%`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+    if (!args[0]) return message.channel.send(currentVolumeEmbed);
+
+    if (Number(args[0]) < 0 || Number(args[0]) > 100) return message.channel.send(errorVolumeEmbed);
+    message.guild.voiceConnection.volume = Number(args[0]) / 100;
+    this.client.playlists.get(message.guild.id).volume = Number(args[0]);
+    this.client.playlists.get(message.guild.id).connection.dispatcher.setVolumeLogarithmic(Number(args[0]) / 100);
+    
+    const volumeSetEmbed = new MessageEmbed()
+      .setAuthor("Volume")
+      .setDescription(`Volume has been set to ${args[0]}%`)
+      .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+    message.channel.send(volumeSetEmbed);
+
+  }
+}
+
+module.exports = Volume;

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class Misaki extends Client {
     this.commands = new Collection();
     this.upvoters = [];
     this.ratelimits = new Collection();
+    this.playlists = new Collection();
 
     this.settings = new Enmap({ provider: new EnmapLevel({ name: "settings" }) });
     

--- a/modules/MusicHandling.js
+++ b/modules/MusicHandling.js
@@ -52,7 +52,7 @@ const handleVideo = async (video, message, voiceChannel, playlist = false) => {
     }
   }
   return;
-}
+};
   
 function play(guild, song) {
   const queue = guild.client.playlists;

--- a/modules/MusicHandling.js
+++ b/modules/MusicHandling.js
@@ -1,0 +1,99 @@
+const { MessageEmbed, Util } = require("discord.js");
+const ytdl = require("ytdl-core");
+
+const handleVideo = async (video, message, voiceChannel, playlist = false) => {
+  const queue = message.client.playlists; 
+  const song = {
+    id: video.id,
+    title: Util.escapeMarkdown(video.title),
+    url: `https://www.youtube.com/watch?v=${video.id}`,
+    channel: video.channel.title,
+    channelurl: `https://www.youtube.com/channel/${video.channel.id}`,
+    durationh: video.duration.hours,
+    durationm: video.duration.minutes,
+    durations: video.duration.seconds,
+    thumbnail: video.thumbnails.default.url,
+    author: message.author.username,
+    requesterid: message.author.id
+  };
+  if (!queue.has(message.guild.id)) {
+    const queueConstruct = {
+      textChannel: message.channel,
+      voiceChannel: voiceChannel,
+      connection: null,
+      songs: [],
+      volume: 5,
+      playing: true,
+      loop: false
+    };
+    queue.set(message.guild.id, queueConstruct);
+    queueConstruct.songs.push(song);
+    try {
+      const connection = await voiceChannel.join();
+      queueConstruct.connection = connection;
+      play(message.guild, queueConstruct.songs[0]);
+    } catch (error) {
+      queue.delete(message.guild.id);
+      const embed = new MessageEmbed()
+        .setAuthor("Error")
+        .setDescription(`An error has occured: ${error}`)
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+  } else {
+    queue.get(message.guild.id).songs.push(song);
+    if (playlist) return;
+    else {
+      const embed = new MessageEmbed()
+        .setAuthor("Song added!")
+        .setDescription(`✅ **${song.title}** has been added to the queue!`)
+        .setColor(message.guild.me.roles.highest.color || 0x00AE86);
+      return message.channel.send(embed);
+    }
+  }
+  return;
+}
+  
+function play(guild, song) {
+  const queue = guild.client.playlists;
+  const serverQueue = queue.get(guild.id);
+  if (!song) {
+    serverQueue.voiceChannel.leave();
+    queue.delete(guild.id);
+    return;
+  }
+  
+  const dispatcher = queue.get(guild.id).connection.play(ytdl(song.url))
+    .on("end", () => {
+      if (!serverQueue.loop) {
+        queue.get(guild.id).songs.shift();
+        setTimeout(() => {
+          play(guild, queue.get(guild.id).songs[0]);
+        }, 250); 
+      } else {
+        setTimeout(() => {
+          play(guild, queue.get(guild.id).songs[0]);
+        }, 250);		   
+      }
+    });
+  dispatcher.setVolumeLogarithmic(queue.get(guild.id).volume / 5);
+  let songdurm, songdurh, songdurs;
+  if (song.durationm < 10) songdurm = "0"+song.durationm;
+  if (song.durationm >= 10) songdurm = song.durationm;
+  if (song.durations < 10) songdurs = "0"+song.durations;
+  if (song.durations >= 10) songdurs = song.durations;
+  if (song.durationh < 10) songdurh = "0"+song.durationh;
+  if (song.durationh >= 10) songdurh = song.durationh;
+    
+  const embed = new MessageEmbed()
+    .setTitle(song.channel)
+    .setURL(song.channelurl)
+    .setThumbnail(song.thumbnail)
+    .setDescription(`[${song.title}](${song.url})`)
+    .addField("__Duration__",`${songdurh}:${songdurm}:${songdurs}`, true)
+    .addField("__Requested by__", song.author, true)
+    .setColor(guild.member(guild.client.user.id).roles.highest.color || 0x00AE86);
+  if (!serverQueue.loop) return queue.get(guild.id).textChannel.send(embed);
+}
+
+module.exports = handleVideo;


### PR DESCRIPTION
This PR introduces 10 new music commands:
- Play
- Search
- Volume
- Pause
- Resume
- Skip
- Stop
- Loop
- Queue 
- NP (Now Playing)

This is a way where I've adapted iCrawl's Music Handling system to work with Misaki, and also have spent a lot of time to make all of the messages embedded to allow Misaki to look more professional and 'clean looking'. This PR will allow Misaki to handle playlists and also live videos alongside the simple 
-play <URL> and -play <search string>, it will also allow users to use -search <search string> which will return a list of 10 songs and inturn, await a response from them which is a number from 1-10 which will then start playing that song, or add it to the queue if there is one. Some example messages:

![](https://youssef.hacked-your.webcam/pofmxIcnN.png) 
That is a live video, so 00:00:00 duration.

Normal video:
![](https://youssef.hacked-your.webcam/BQBKiuvUC.png)