### PR TITLE
Update to help.js

### DIFF
--- a/commands/general/help.js
+++ b/commands/general/help.js
@@ -47,7 +47,7 @@ class Help extends Command {
           .addField("Command description", cm.help.description)
           .addField("Command usage", `\`${cm.help.usage}\``)
           .addField("Command aliases", cm.conf.aliases.length === 0 ? "None" : cm.conf.aliases.join(", ") )
-          .addField("Extended description", cm.help.extended ? cm.help.extended : "None");
+          .addField("Extended description", cm.help.extended);
 
       } else {
         let n = 0;

--- a/commands/general/help.js
+++ b/commands/general/help.js
@@ -46,7 +46,8 @@ class Help extends Command {
         embed.setTitle(cm.help.name.toProperCase())
           .addField("Command description", cm.help.description)
           .addField("Command usage", `\`${cm.help.usage}\``)
-          .addField("Command aliases", cm.conf.aliases.length === 0 ? "None" : cm.conf.aliases.join(", ") );
+          .addField("Command aliases", cm.conf.aliases.length === 0 ? "None" : cm.conf.aliases.join(", ") )
+          .addField("Extended description", cm.help.extended ? cm.help.extended : "None");
 
       } else {
         let n = 0;


### PR DESCRIPTION
This PR updates the ``help.js`` command.

Adds **Extended Description** to the embed.
![Extended Desc](https://i.andrew-is.online/i/r2swm.png)

The field still remains if there is no extended description, but reflects that it does not have any.
![No Extended Desc](https://i.andrew-is.online/i/gk48j.png)