### PR TITLE
Update to make commands usable in DMs

### DIFF
--- a/extenders/Message.js
+++ b/extenders/Message.js
@@ -7,6 +7,11 @@ module.exports = Structures.extend("Message", Message => class extends Message {
 
     this.flags = [];
   }
+  
+  get member() {
+    if (this.guild) return super.member;
+    return { "user": this.channel.recipient, "displayName": this.channel.recipient.username };
+  }
 
   response(emoji = "❌", content, embed, options = {}) {
     return this.channel.send(`${this.author} \`|${emoji}|\` ${content}`, Object.assign({}, options,  { embed }));


### PR DESCRIPTION
It correctly gets the author's username. The code pulls it using ``message.member.displayName``.
![Username](https://i.andrew-is.online/i/osakx.png) 

Replaced the ``member`` object with required information.
![Eval](https://i.andrew-is.online/i/wyatu.png)

- [x] This PR changes the framework's interface (methods or parameters added)