### PR TITLE
fix(Reloading): Pass the original path to the piece instead of the joined path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,14 +606,14 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "discord.js": {
-      "version": "github:discordjs/discord.js#f2dd3cf26b5917f420cac9f74a220e45895cb714",
+      "version": "github:discordjs/discord.js#e1e1d1b20d8e91313c6e11cb1910ef7004b30acf",
       "requires": {
-        "pako": "1.0.6",
-        "prism-media": "0.2.1",
-        "setimmediate": "1.0.5",
+        "pako": "^1.0.0",
+        "prism-media": "^0.2.0",
+        "setimmediate": "^1.0.5",
         "snekfetch": "3.6.4",
-        "tweetnacl": "1.0.0",
-        "ws": "4.1.0"
+        "tweetnacl": "^1.0.0",
+        "ws": "^4.0.0"
       }
     },
     "doctrine": {
@@ -2481,7 +2481,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
-        "async-limiter": "1.0.0",
+        "async-limiter": "~1.0.0",
         "safe-buffer": "5.1.1"
       }
     },

--- a/structures/Store.js
+++ b/structures/Store.js
@@ -28,7 +28,7 @@ class Store extends Collection {
     const filepath = path.join(this.dir, file);
     try {
       const parsedFile = {
-        path: filepath,
+        path: file,
         name: path.parse(filepath).name
       };
       const piece = this.set(new (require(filepath))(this.client, parsedFile));

--- a/util/util.js
+++ b/util/util.js
@@ -7,16 +7,6 @@ class Util {
     return str.replace(Util.REGEXPESC, "\\$&");
   }
 
-  static arrDiff(a, b) {
-    if (a === b) return [];
-
-    for (const item of a) {
-      const ind = b.indexOf(item);
-      if (ind !== -1) b.splice(ind, 1);
-    }
-
-    return b;
-  }
 }
 
 Util.wait = require("util").promisify(setTimeout);


### PR DESCRIPTION
This PR fixes command/event reloading and removes arrDiff from Util as it is not used anywhere in Misaki.